### PR TITLE
Fix duplicate transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "jsonwebtoken": "^8.5.1",
         "node-fetch": "^2.6.6",
         "playwright": "^1.16.1",
-        "source-map-support": "^0.5.16"
+        "source-map-support": "^0.5.16",
+        "string-hash": "^1.1.3"
       },
       "bin": {
         "transaction-service": "bin/transaction-service.js"
@@ -29,6 +30,7 @@
         "@types/jest": "^26.0.10",
         "@types/jsonwebtoken": "^8.5.5",
         "@types/node": "10.17.27",
+        "@types/string-hash": "^1.1.1",
         "aws-cdk": "1.129.0",
         "esbuild": "^0.13.13",
         "jest": "^26.4.2",
@@ -4609,6 +4611,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "node_modules/@types/string-hash": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/string-hash/-/string-hash-1.1.1.tgz",
+      "integrity": "sha512-ijt3zdHi2DmZxQpQTmozXszzDo78V4R3EdvX0jFMfnMH2ZzQSmCbaWOMPGXFUYSzSIdStv78HDjg32m5dxc+tA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -11301,6 +11309,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/string-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -15120,6 +15133,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "@types/string-hash": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/string-hash/-/string-hash-1.1.1.tgz",
+      "integrity": "sha512-ijt3zdHi2DmZxQpQTmozXszzDo78V4R3EdvX0jFMfnMH2ZzQSmCbaWOMPGXFUYSzSIdStv78HDjg32m5dxc+tA==",
       "dev": true
     },
     "@types/yargs": {
@@ -20651,6 +20670,11 @@
           "dev": true
         }
       }
+    },
+    "string-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
+      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
     },
     "string-length": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/jest": "^26.0.10",
     "@types/jsonwebtoken": "^8.5.5",
     "@types/node": "10.17.27",
+    "@types/string-hash": "^1.1.1",
     "aws-cdk": "1.129.0",
     "esbuild": "^0.13.13",
     "jest": "^26.4.2",
@@ -46,6 +47,7 @@
     "jsonwebtoken": "^8.5.1",
     "node-fetch": "^2.6.6",
     "playwright": "^1.16.1",
-    "source-map-support": "^0.5.16"
+    "source-map-support": "^0.5.16",
+    "string-hash": "^1.1.3"
   }
 }

--- a/src/lambdas/update-transaction/transaction-parser.ts
+++ b/src/lambdas/update-transaction/transaction-parser.ts
@@ -1,3 +1,4 @@
+import { IdGenerator } from "@shared/persistence/id-generator"
 import { Transaction, TransactionSource, AccwebTransaction } from "@shared/types"
 import { Middleware } from "./transaction-parser-middlewares/middleware"
 
@@ -19,12 +20,8 @@ export class TransactionParser {
   }
 
   parseSingle(transaction: AccwebTransaction): Transaction {
-    const postedAt = (transaction.dateInscription == undefined)
-      ? undefined
-      : Date.parse(transaction.dateInscription)
-
     const result: Transaction = {
-      id: transaction.identifiant,
+      id: this.generateId(transaction),
       description: transaction.descriptionSimplifiee,
       fullDescription: transaction.descriptionCourte,
       category: this.parseCategory(transaction.categorieParentTransaction),
@@ -35,13 +32,17 @@ export class TransactionParser {
       source: this.parseSource(transaction),
       isExpensed: false,
       timestamps: {
-        postedAt: postedAt,
+        postedAt: Date.parse(transaction.dateInscription),
         authorizedAt: Date.parse(transaction.dateTransaction)
       }
     }
     return this.applyMiddlewares(result)
   }
 
+  private generateId(transaction: AccwebTransaction) {
+    const generator = new IdGenerator()
+    return generator.generateId(transaction)
+  }
   private applyMiddlewares(transaction: Transaction): Transaction {
     let result = transaction
 

--- a/src/lambdas/update-transaction/transaction-parser.ts
+++ b/src/lambdas/update-transaction/transaction-parser.ts
@@ -19,7 +19,7 @@ export class TransactionParser {
   }
 
   parseSingle(transaction: AccwebTransaction): Transaction {
-    const authorizedAt = (transaction.dateTransaction == undefined)
+    const postedAt = (transaction.dateTransaction == undefined)
       ? undefined
       : Date.parse(transaction.dateTransaction)
 
@@ -35,8 +35,8 @@ export class TransactionParser {
       source: this.parseSource(transaction),
       isExpensed: false,
       timestamps: {
-        authorizedAt: authorizedAt,
-        postedAt: Date.parse(transaction.dateInscription)
+        postedAt: postedAt,
+        authorizedAt: Date.parse(transaction.dateInscription)
       }
     }
     return this.applyMiddlewares(result)

--- a/src/lambdas/update-transaction/transaction-parser.ts
+++ b/src/lambdas/update-transaction/transaction-parser.ts
@@ -19,9 +19,9 @@ export class TransactionParser {
   }
 
   parseSingle(transaction: AccwebTransaction): Transaction {
-    const postedAt = (transaction.dateTransaction == undefined)
+    const postedAt = (transaction.dateInscription == undefined)
       ? undefined
-      : Date.parse(transaction.dateTransaction)
+      : Date.parse(transaction.dateInscription)
 
     const result: Transaction = {
       id: transaction.identifiant,
@@ -36,7 +36,7 @@ export class TransactionParser {
       isExpensed: false,
       timestamps: {
         postedAt: postedAt,
-        authorizedAt: Date.parse(transaction.dateInscription)
+        authorizedAt: Date.parse(transaction.dateTransaction)
       }
     }
     return this.applyMiddlewares(result)

--- a/src/shared/networking/transaction-service-client.ts
+++ b/src/shared/networking/transaction-service-client.ts
@@ -5,6 +5,10 @@ export interface TransactionUpdatePayload {
   type: string
 }
 
+export interface UpdateTransactionResponse {
+  transaction: Transaction
+}
+
 export interface AccwebUpdatePayload extends TransactionUpdatePayload {
   sourceName: string
   transaction: AccwebTransaction
@@ -21,7 +25,7 @@ export class TransactionServiceClient {
     this.props = props
   }
 
-  updateTransaction(payload: AccwebUpdatePayload): Promise<Transaction[]> {
+  updateTransaction(payload: AccwebUpdatePayload): Promise<UpdateTransactionResponse> {
     return fetch(`${this.props.baseUrl}/transactions`, {
       method: "PUT",
       body: JSON.stringify(payload),
@@ -33,7 +37,7 @@ export class TransactionServiceClient {
     })
     .then(this.validateResponse)
     .then(res => res.json())
-    .then(json => json as Transaction[])
+    .then(json => json as UpdateTransactionResponse)
   }
 
   private async validateResponse(response: Response): Promise<Response> {

--- a/src/shared/persistence/datasource-mutation.ts
+++ b/src/shared/persistence/datasource-mutation.ts
@@ -25,14 +25,14 @@ export class PersistTransaction implements Mutation {
     const transaction = this.props.transaction
     const now = Date.now()
     const createdAt = transaction.timestamps.created_at || now
-    const postedAt = new Date(transaction.timestamps.postedAt)
+    const authorizedAt = new Date(transaction.timestamps.authorizedAt)
 
     return {
       Put: {
         TableName: this.props.tableName,
         Item: {
           ...transaction,
-          resourceId: `transaction/${postedAt.getFullYear()}-${postedAt.getMonth() + 1}`,
+          resourceId: `transaction/${authorizedAt.getFullYear()}-${authorizedAt.getMonth() + 1}`,
           sortKey: `id/${transaction.id}`,
           timestamps: {
             ...transaction.timestamps,

--- a/src/shared/persistence/id-generator.ts
+++ b/src/shared/persistence/id-generator.ts
@@ -1,0 +1,9 @@
+import { AccwebTransaction } from "@shared/types"
+
+const hash = require("string-hash")
+
+export class IdGenerator {
+  generateId(transaction: AccwebTransaction) {
+    return `txn_${hash(`${transaction.dateTransaction}${transaction.montantDevise}`)}`
+  }
+}

--- a/src/shared/persistence/id-generator.ts
+++ b/src/shared/persistence/id-generator.ts
@@ -4,6 +4,9 @@ const hash = require("string-hash")
 
 export class IdGenerator {
   generateId(transaction: AccwebTransaction) {
-    return `txn_${hash(`${transaction.dateTransaction}${transaction.montantDevise}`)}`
+    const date = hash(transaction.dateTransaction)
+    const amount = hash(transaction.montantTransaction)
+    const name = hash(transaction.descriptionCourte)
+    return `txn_${date}${amount}${name}`
   }
 }

--- a/src/shared/persistence/id-generator.ts
+++ b/src/shared/persistence/id-generator.ts
@@ -4,7 +4,7 @@ const hash = require("string-hash")
 
 export class IdGenerator {
   generateId(transaction: AccwebTransaction) {
-    const date = hash(transaction.dateTransaction)
+    const date = hash(transaction.dateInscription)
     const amount = hash(transaction.montantTransaction)
     const name = hash(transaction.descriptionCourte)
     return `txn_${date}${amount}${name}`

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -19,7 +19,7 @@ export interface Transaction {
     updatedAt?: number,
     authorizedAt: number,
     deleted_at?: number,
-    postedAt?: number
+    postedAt: number
   }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -17,9 +17,9 @@ export interface Transaction {
   timestamps: {
     created_at?: number,
     updatedAt?: number,
-    authorizedAt?: number,
+    authorizedAt: number,
     deleted_at?: number,
-    postedAt: number
+    postedAt?: number
   }
 }
 

--- a/src/shared/validation/ingestion-validator.ts
+++ b/src/shared/validation/ingestion-validator.ts
@@ -16,19 +16,26 @@ export class IngestionValidator {
   }
 
   private validateIds(transactions: Transaction[]): Error[] {
-    let countByIsd: { [key: string]: number } = {}
+    let transactionByIds: { [key: string]: Transaction[] } = {}
 
     transactions.forEach(txn => {
-      const count = countByIsd[txn.id] ?? 0
-      countByIsd[txn.id] = count + 1
+      let list = transactionByIds[txn.id] ?? []
+      list.push(txn)
+      transactionByIds[txn.id] = list
     })
 
+    return this.errorsForDuplicateIds(transactionByIds)
+  }
+
+  private errorsForDuplicateIds(hash: { [key: string]: Transaction[] }) {
     let errors: Error[] = []
 
-    Object.keys(countByIsd).forEach(id => {
-      const count = countByIsd[id]
+    Object.keys(hash).forEach(id => {
+      const transactions = hash[id]
+      const count = transactions.length
       if (count <= 1) return
-      const error = new Error(`Found ${count} duplicate transaction ids: ${id}`)
+      const descriptions = transactions.map(txn => txn.description).join(", ")
+      const error = new Error(`Found ${count} duplicate transaction ids ${id} with descriptions: ${descriptions}`)
       errors.push(error)
     })
 

--- a/src/shared/validation/ingestion-validator.ts
+++ b/src/shared/validation/ingestion-validator.ts
@@ -1,0 +1,37 @@
+import { Transaction } from "@shared/types"
+
+export class IngestionOutput {
+  errors: Error[]
+}
+
+export class IngestionValidator {
+  validate(transactions: Transaction[]): IngestionOutput {
+    let output: IngestionOutput = { errors: [] }
+
+    this.validateIds(transactions).forEach(error => {
+      output.errors.push(error)
+    })
+
+    return output
+  }
+
+  private validateIds(transactions: Transaction[]): Error[] {
+    let countByIsd: { [key: string]: number } = {}
+
+    transactions.forEach(txn => {
+      const count = countByIsd[txn.id] ?? 0
+      countByIsd[txn.id] = count + 1
+    })
+
+    let errors: Error[] = []
+
+    Object.keys(countByIsd).forEach(id => {
+      const count = countByIsd[id]
+      if (count <= 1) return
+      const error = new Error(`Found ${count} duplicate transaction ids: ${id}`)
+      errors.push(error)
+    })
+
+    return errors
+  }
+}

--- a/test/factories.ts
+++ b/test/factories.ts
@@ -12,7 +12,7 @@ export function createTransaction(attributes: any): types.Transaction {
       name: "source_name"
     },
     timestamps: {
-      postedAt: Date.now()
+      authorizedAt: Date.now()
     },
     ...attributes
   }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -32,7 +32,7 @@ export const accwebTransactions: AccwebTransaction[] = [
     "typeTransaction": "AutreAutorisation",
     "descriptionCourte": "CENTRE DE JEUX EXPEDIT - Full desc",
     "descriptionSimplifiee": "Centre De Jeux Expedit",
-    "dateTransaction": "2021-10-24T20:02:43Z",
+    "dateTransaction": "2021-10-20T20:02:43Z",
     "devise": "CAD",
     "numeroCarteMasque": "2121 21** **** 0000",
     "codeRelation": "P"

--- a/test/lambdas/update-transaction/accweb-updater.test.ts
+++ b/test/lambdas/update-transaction/accweb-updater.test.ts
@@ -39,7 +39,7 @@ describe("AccwebUpdater", () => {
 
     describe("when a transaction with the same id already exists", () => {
       beforeEach(() => {
-        const existingVersion = factories.createTransaction({ id: "id-2", isExpensed: true })
+        const existingVersion = factories.createTransaction({ id: "txn_3730012052", isExpensed: true })
         repo.transactions.push(existingVersion)
       })
 

--- a/test/lambdas/update-transaction/accweb-updater.test.ts
+++ b/test/lambdas/update-transaction/accweb-updater.test.ts
@@ -39,7 +39,7 @@ describe("AccwebUpdater", () => {
 
     describe("when a transaction with the same id already exists", () => {
       beforeEach(() => {
-        const existingVersion = factories.createTransaction({ id: "txn_3730012052", isExpensed: true })
+        const existingVersion = factories.createTransaction({ id: "txn_37561336141111237231129609267", isExpensed: true })
         repo.transactions.push(existingVersion)
       })
 

--- a/test/lambdas/update-transaction/transaction-parser.test.ts
+++ b/test/lambdas/update-transaction/transaction-parser.test.ts
@@ -74,15 +74,15 @@ describe("TransactionParser", () => {
 
     it("parses the posted dates", () => {
       expect(transactions.map(t => t.timestamps.postedAt)).toEqual([
-        1631728207000,
-        1635105763000
+        1631750400000,
+        1634860800000
       ])
     })
 
     it("parses the authorization date", () => {
       expect(transactions.map(t => t.timestamps.authorizedAt)).toEqual([
-        1631750400000,
-        1634860800000
+        1631728207000,
+        1634760163000
       ])
     })
   })

--- a/test/lambdas/update-transaction/transaction-parser.test.ts
+++ b/test/lambdas/update-transaction/transaction-parser.test.ts
@@ -19,8 +19,8 @@ describe("TransactionParser", () => {
 
     it("parses the ids", () => {
       expect(transactions.map(t => t.id)).toEqual([
-        "txn_3441011389",
-        "txn_3730012052"
+        "txn_133591027536626244433877038067",
+        "txn_37561336141111237231129609267"
       ])
     })
 

--- a/test/lambdas/update-transaction/transaction-parser.test.ts
+++ b/test/lambdas/update-transaction/transaction-parser.test.ts
@@ -18,7 +18,10 @@ describe("TransactionParser", () => {
     })
 
     it("parses the ids", () => {
-      expect(transactions.map(t => t.id)).toEqual(["id-1", "id-2"])
+      expect(transactions.map(t => t.id)).toEqual([
+        "txn_3441011389",
+        "txn_3730012052"
+      ])
     })
 
     it("parses the categories", () => {

--- a/test/lambdas/update-transaction/transaction-parser.test.ts
+++ b/test/lambdas/update-transaction/transaction-parser.test.ts
@@ -74,15 +74,15 @@ describe("TransactionParser", () => {
 
     it("parses the posted dates", () => {
       expect(transactions.map(t => t.timestamps.postedAt)).toEqual([
-        1631750400000,
-        1634860800000
+        1631728207000,
+        1635105763000
       ])
     })
 
     it("parses the authorization date", () => {
       expect(transactions.map(t => t.timestamps.authorizedAt)).toEqual([
-        1631728207000,
-        1635105763000
+        1631750400000,
+        1634860800000
       ])
     })
   })

--- a/test/shared/persistence/id-generator.test.ts
+++ b/test/shared/persistence/id-generator.test.ts
@@ -7,7 +7,7 @@ describe("IdGenerator", () => {
       const transaction = fixtures.accwebTransactions[0]
       const generator = new IdGenerator()
       const id = generator.generateId(transaction)
-      expect(id).toEqual("txn_3441011389")
+      expect(id).toEqual("txn_133591027536626244433877038067")
     })
   })
 })

--- a/test/shared/persistence/id-generator.test.ts
+++ b/test/shared/persistence/id-generator.test.ts
@@ -1,0 +1,13 @@
+import { IdGenerator } from "@shared/persistence/id-generator"
+import * as fixtures from "../../fixtures"
+
+describe("IdGenerator", () => {
+  describe("generateId", () => {
+    it("generates Accweb transaction ids", () => {
+      const transaction = fixtures.accwebTransactions[0]
+      const generator = new IdGenerator()
+      const id = generator.generateId(transaction)
+      expect(id).toEqual("txn_3441011389")
+    })
+  })
+})

--- a/test/shared/persistence/transaction-repository.test.ts
+++ b/test/shared/persistence/transaction-repository.test.ts
@@ -21,7 +21,7 @@ describe("PersistedTransactionRepository", () => {
 
       expect(dataSource.queries[0].toInput()).toMatchObject({
         TableName: "test_table",
-        ConsistentRead: true,
+        ConsistentRead: false,
         KeyConditionExpression: "sortKey = :sortKey",
         ExpressionAttributeValues: {
           ":sortKey": "id/1234"
@@ -60,7 +60,7 @@ describe("PersistedTransactionRepository", () => {
       version: undefined,
       category: "Food",
       timestamps: {
-        postedAt: 1640482950
+        authorizedAt: 1640482950
       }
     })
 
@@ -83,7 +83,7 @@ describe("PersistedTransactionRepository", () => {
                 description: expect.any(String),
                 fullDescription: expect.any(String),
                 timestamps: {
-                  postedAt: 1640482950,
+                  authorizedAt: 1640482950,
                   updatedAt: expect.any(Number),
                 }
               }

--- a/test/shared/validation/ingestion-validator.test.ts
+++ b/test/shared/validation/ingestion-validator.test.ts
@@ -7,17 +7,17 @@ describe("IngestionValidator", () => {
   describe("validate", () => {
     it("returns all duplicate ids", () => {
       const output = subject.validate([
-        factories.createTransaction({ id: "1" }),
-        factories.createTransaction({ id: "2" }),
-        factories.createTransaction({ id: "2" }),
-        factories.createTransaction({ id: "1" }),
-        factories.createTransaction({ id: "2" }),
-        factories.createTransaction({ id: "4" })
+        factories.createTransaction({ id: "1", description: "Saint-Henri" }),
+        factories.createTransaction({ id: "2", description: "Larue" }),
+        factories.createTransaction({ id: "2", description: "HUIT" }),
+        factories.createTransaction({ id: "1", description: "Dispatch" }),
+        factories.createTransaction({ id: "2", description: "Standard" }),
+        factories.createTransaction({ id: "4", description: "Myriade" })
       ])
 
       expect(output.errors.map(e => e.message)).toEqual([
-        "Found 2 duplicate transaction ids: 1",
-        "Found 3 duplicate transaction ids: 2"
+        "Found 2 duplicate transaction ids 1 with descriptions: Saint-Henri, Dispatch",
+        "Found 3 duplicate transaction ids 2 with descriptions: Larue, HUIT, Standard"
       ])
     })
   })

--- a/test/shared/validation/ingestion-validator.test.ts
+++ b/test/shared/validation/ingestion-validator.test.ts
@@ -1,0 +1,24 @@
+import { IngestionValidator } from "@shared/validation/ingestion-validator"
+import * as factories from "../../factories"
+
+describe("IngestionValidator", () => {
+  const subject = new IngestionValidator()
+
+  describe("validate", () => {
+    it("returns all duplicate ids", () => {
+      const output = subject.validate([
+        factories.createTransaction({ id: "1" }),
+        factories.createTransaction({ id: "2" }),
+        factories.createTransaction({ id: "2" }),
+        factories.createTransaction({ id: "1" }),
+        factories.createTransaction({ id: "2" }),
+        factories.createTransaction({ id: "4" })
+      ])
+
+      expect(output.errors.map(e => e.message)).toEqual([
+        "Found 2 duplicate transaction ids: 1",
+        "Found 3 duplicate transaction ids: 2"
+      ])
+    })
+  })
+})


### PR DESCRIPTION
We can't rely on the Accweb identifier since it changes depending on the session for any given transactions.